### PR TITLE
Add zdns for bulk reverse and forward DNS in SameKeys.py

### DIFF
--- a/SameKeys.py
+++ b/SameKeys.py
@@ -67,6 +67,86 @@ def zdns_ptr_bulk(ips):
     return result
 
 
+def zdns_a_bulk(names):
+    # Create a zdns subprocess for a forward A lookup (100 in a batch)
+    # Returns {name: ip}.
+    names=[n for n in names if n]
+    if not names:
+        return {}
+    try:
+        proc=subprocess.Popen(['zdns','A'],
+                              stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        out,_=proc.communicate(input=("\n".join(names)+"\n").encode())
+    except FileNotFoundError:
+        raise RuntimeError("Issue with zdns, check the command works")
+    result={}
+    for line in out.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj=json.loads(line)
+        except Exception:
+            continue
+        name=obj.get('name')
+        ar=obj.get('results',{}).get('A',{})
+        if ar.get('status')!='NOERROR':
+            continue
+        for a in ar.get('data',{}).get('answers',[]):
+            if a.get('type')=='A':
+                result[name]=a.get('answer','')
+                break
+    return result
+
+
+def candidate_names_for_blob(blob):
+    # Mirror the main loop's name extraction. Returns a set of candidate
+    # hostnames from p25 banner plus cert DN/SANs across all scanned ports.
+    names=set()
+    writer=blob.get('writer','')
+    # banner from p25
+    try:
+        if writer=='FreshGrab.py':
+            banner=blob['p25']['data']['banner']
+        else:
+            banner=blob['p25']['smtp']['starttls']['banner']
+        ts=banner.split()
+        if ts[0]=='220':
+            names.add(ts[1])
+        elif ts[0].startswith('220-'):
+            names.add(ts[0][4:])
+    except Exception:
+        pass
+    # cert names from each port - mirror the main loop's cert paths exactly
+    tmp={}
+    for port in ('p25','p110','p143','p443','p587','p993'):
+        try:
+            if writer=='FreshGrab.py':
+                if port=='p443':
+                    cert=blob[port]['data']['http']['response']['request']['tls_handshake']['server_certificates']['certificate']
+                else:
+                    cert=blob[port]['data']['tls']['server_certificates']['certificate']
+            else:
+                if port=='p25':
+                    cert=blob[port]['smtp']['starttls']['tls']['certificate']
+                elif port in ('p110','p143'):
+                    cert=blob[port]['pop3']['starttls']['tls']['certificate']
+                elif port=='p443':
+                    cert=blob[port]['https']['tls']['certificate']
+                elif port=='p993':
+                    cert=blob[port]['imaps']['tls']['tls']['certificate']['parsed']
+                else:
+                    continue
+            get_certnames(port,cert,tmp)
+        except Exception:
+            pass
+    for v in tmp.values():
+        if v:
+            names.add(v)
+    return names
+
+
 # default values
 infile="records.fresh"
 outfile="collisions.json"
@@ -166,6 +246,20 @@ else:
     print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
     ptr_dict=zdns_ptr_bulk(ptr_ips)
     print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
+
+    # using zdns to do a forward-DNS lookup in bulk
+    candidate_names=set()
+    candidate_names.update(v for v in ptr_dict.values() if v)
+    with open(infile,'r') as f:
+        for line in f:
+            try:
+                blob=json.loads(line)
+            except Exception:
+                continue
+            candidate_names.update(candidate_names_for_blob(blob))
+    print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
+    forward_dict=zdns_a_bulk(candidate_names)
+    print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)
 
     with open(infile,'r') as f:
         for line in f:
@@ -353,24 +447,20 @@ else:
             besty=[]
             nogood=True # assume none are good
             tmp={}
-            # try verify names a bit
+            # try verify names a bit (forward A looked up in bulk by zdns before the loop)
             for k in nameset:
                 v=nameset[k]
                 #print "checking: " + k + " " + v
                 # see if we can verify the value as matching our give IP
                 if v != '' and not fqdn_bogon(v):
-                    try:
-                        rip=socket.gethostbyname(v)
+                    rip=forward_dict.get(v)
+                    if rip is not None:
                         if rip == thisone.ip:
                             besty.append(k)
                         else:
                             tmp[k+'-ip']=rip
                         # some name has an IP, even if not what we expect
                         nogood=False
-                    except Exception as e: 
-                        #oddly, an NXDOMAIN seems to cause an exception, so these happen
-                        #print >> sys.stderr, "Error making DNS query for " + v + " for ip:" + thisone.ip + " " + str(e)
-                        pass
             for k in tmp:
                 nameset[k]=tmp[k]
             nameset['allbad']=nogood

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -38,7 +38,7 @@ from SurveyFuncs import *
 
 
 def zdns_ptr_bulk(ips):
-    # Create a zdns subprocess for a lookup (100 in a batch) 
+    # Create a zdns subprocess for a PTR lookup (100 in a batch)
     # Returns {ip: rdns}.
     try:
         proc=subprocess.Popen(['zdns','PTR'],
@@ -100,9 +100,8 @@ def zdns_a_bulk(names):
     return result
 
 
-def candidate_names_for_blob(blob):
-    # Mirror the main loop's name extraction. Returns a set of candidate
-    # hostnames from p25 banner plus cert DN/SANs across all scanned ports.
+def get_hostnames(blob):
+    # Returns a set of hostnames from p25 banner and DN/SANs across all scanned ports.
     names=set()
     writer=blob.get('writer','')
     # banner from p25
@@ -118,7 +117,6 @@ def candidate_names_for_blob(blob):
             names.add(ts[0][4:])
     except Exception:
         pass
-    # cert names from each port - mirror the main loop's cert paths exactly
     tmp={}
     for port in ('p25','p110','p143','p443','p587','p993'):
         try:
@@ -256,7 +254,7 @@ else:
                 blob=json.loads(line)
             except Exception:
                 continue
-            candidate_names.update(candidate_names_for_blob(blob))
+            candidate_names.update(get_hostnames(blob))
     print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
     forward_dict=zdns_a_bulk(candidate_names)
     print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -37,7 +37,7 @@ import pytz # for adding back TZ info to allow comparisons
 from SurveyFuncs import *
 
 
-def zdns_ptr_bulk(ips):
+def zdns_ptr(ips):
     # Create a zdns subprocess for a PTR lookup (100 in a batch)
     # Returns {ip: rdns}.
     try:
@@ -67,7 +67,7 @@ def zdns_ptr_bulk(ips):
     return result
 
 
-def zdns_a_bulk(names):
+def zdns_a(names):
     # Create a zdns subprocess for a forward A lookup (100 in a batch)
     # Returns {name: ip}.
     names=[n for n in names if n]
@@ -233,7 +233,7 @@ else:
     # keep track of how long this is taking per ip
     peripaverage=0
 
-    # using zdns to do a reverse-DNS lookup in bulk
+    # using zdns to do a reverse-DNS lookup
     ptr_ips=[]
     with open(infile,'r') as f:
         for line in f:
@@ -242,10 +242,10 @@ else:
             except Exception:
                 pass
     print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
-    ptr_dict=zdns_ptr_bulk(ptr_ips)
+    ptr_dict=zdns_ptr(ptr_ips)
     print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
 
-    # using zdns to do a forward-DNS lookup in bulk
+    # using zdns to do a forward-DNS lookup
     candidate_names=set()
     candidate_names.update(v for v in ptr_dict.values() if v)
     with open(infile,'r') as f:
@@ -256,7 +256,7 @@ else:
                 continue
             candidate_names.update(get_hostnames(blob))
     print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
-    forward_dict=zdns_a_bulk(candidate_names)
+    forward_dict=zdns_a(candidate_names)
     print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)
 
     with open(infile,'r') as f:
@@ -302,7 +302,7 @@ else:
     
             thisone.analysis['nameset']={}
             nameset=thisone.analysis['nameset']
-            # name from reverse DNS (looked up in bulk by zdns before the loop)
+            # name from reverse DNS (looked up by zdns before the loop)
             rdns=ptr_dict.get(thisone.ip)
             if rdns is not None:
                 nameset['rdns']=rdns
@@ -445,7 +445,7 @@ else:
             besty=[]
             nogood=True # assume none are good
             tmp={}
-            # try verify names a bit (forward A looked up in bulk by zdns before the loop)
+            # try verify names a bit (forward A looked up by zdns before the loop)
             for k in nameset:
                 v=nameset[k]
                 #print "checking: " + k + " " + v

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -26,7 +26,7 @@
 # figure out if we can get port 587 ever - looks like not, for now anyway
 # my FreshGrab's do have that but we don't for censys.io's Nov 2017 scans
 
-import os, sys, argparse, tempfile, gc
+import os, sys, argparse, tempfile, gc, subprocess
 import json
 import jsonpickle # install via  "$ sudo pip install -U jsonpickle"
 import time, datetime
@@ -34,7 +34,38 @@ from dateutil import parser as dparser  # for parsing time from comand line and 
 import pytz # for adding back TZ info to allow comparisons
 
 # our own stuff
-from SurveyFuncs import *  
+from SurveyFuncs import *
+
+
+def zdns_ptr_bulk(ips):
+    # Create a zdns subprocess for a lookup (100 in a batch) 
+    # Returns {ip: rdns}.
+    try:
+        proc=subprocess.Popen(['zdns','PTR'],
+                              stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        out,_=proc.communicate(input=("\n".join(ips)+"\n").encode())
+    except FileNotFoundError:
+        raise RuntimeError("Issue with zdns, check the command works")
+    result={}
+    for line in out.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj=json.loads(line)
+        except Exception:
+            continue
+        ip=obj.get('name')
+        ptr=obj.get('results',{}).get('PTR',{})
+        if ptr.get('status')!='NOERROR':
+            continue
+        for a in ptr.get('data',{}).get('answers',[]):
+            if a.get('type')=='PTR':
+                result[ip]=a.get('answer','').rstrip('.')
+                break
+    return result
+
 
 # default values
 infile="records.fresh"
@@ -123,7 +154,19 @@ else:
     bads={}
     # keep track of how long this is taking per ip
     peripaverage=0
-    
+
+    # using zdns to do a reverse-DNS lookup in bulk
+    ptr_ips=[]
+    with open(infile,'r') as f:
+        for line in f:
+            try:
+                ptr_ips.append(json.loads(line)['ip'].strip())
+            except Exception:
+                pass
+    print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
+    ptr_dict=zdns_ptr_bulk(ptr_ips)
+    print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
+
     with open(infile,'r') as f:
         for line in f:
             ipstart=time.time()
@@ -167,16 +210,10 @@ else:
     
             thisone.analysis['nameset']={}
             nameset=thisone.analysis['nameset']
-            try:
-                # name from reverse DNS
-                rdnsrec=socket.gethostbyaddr(thisone.ip)
-                rdns=rdnsrec[0]
-                #print "FQDN reverse: " + str(rdns)
+            # name from reverse DNS (looked up in bulk by zdns before the loop)
+            rdns=ptr_dict.get(thisone.ip)
+            if rdns is not None:
                 nameset['rdns']=rdns
-            except Exception as e: 
-                #print >> sys.stderr, "FQDN reverse exception " + str(e) + " for record:" + thisone.ip
-                #nameset['rdns']=''
-                pass
     
             # name from banner
             try:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,12 +137,13 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
-# add zdns
-go get github.com/zmap/zdns
-cd $GOPATH/src/github.com/zmap/zdns/zdns
-go build
-# add to path
-sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
+# add zdns - install disabled, current zdns needs Go >=1.25 (this
+# script still pins Go 1.10) and the repo layout has changed.
+# Recipe will be reinstated by the zgrab2 PR once the Go pin is bumped.
+#go get github.com/zmap/zdns
+#cd $GOPATH/src/github.com/zmap/zdns/zdns
+#go build
+#sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
 
 # get ciphersuite stuff
 cd $HOME/code/surveys/clustertools

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,6 +137,13 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
+# add zdns
+go get github.com/zmap/zdns
+cd $GOPATH/src/github.com/zmap/zdns/zdns
+go build
+# add to path
+sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
+
 # get ciphersuite stuff
 cd $HOME/code/surveys/clustertools
 if [ ! -f mapping-rfc.txt ]


### PR DESCRIPTION
## Summary

- Add zdns to `install-deps.sh`
- Replace `socket.gethostbyaddr` and `socket.gethostbyname` which before was serial per-IP/name processes.
  - `socket.gethostbyaddr`: uses a zdns subprocess for reverse DNS / PTR
  - `socket.gethostbyname`: uses a zdns subprocess for forward DNS / A

## How Was It Tested

I ran `SameKeys.py` against the existing `records.fresh` from a previous scan on March 21st (IE-20260321, 19,251 Irish records).

The same dataset was run twice on the same VPS: once with the `master` branch code, once with this branch. Before each run I cleared the resolver cache with `resolvectl flush-caches`.

| Branch | Wall clock |
|---|---|
| master | **2h 35m 30s** |
| this PR | **19m 40s** |

The output was checked to make sure the behaviour was preserved.