### PR TITLE
Migrate zgrab to zgrab2 in FreshGrab.py

### DIFF
--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -72,7 +72,7 @@ pparms={
         '25': 'smtp --port 25',
         '110': 'pop3 --port 110 --starttls',
         '143': 'imap --port 143 --starttls',
-        '443': 'http --port 443 --use-https',
+        '443': 'http --port 443 --use-https --max-redirects=5',
         '587': 'smtp --port 587',
         '993': 'imap --port 993 --imaps',
         }

--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import os, sys, argparse, tempfile, gc
+import os, sys, argparse, tempfile, gc, socket
 import json, jsonpickle
 import time
 import subprocess
@@ -66,15 +66,21 @@ if args.country is not None:
 # default timeout for zgrab2, in seconds
 ztimeout=' -t 2s'
 
+# find our own IP, used as the EHLO/HELO name on the SMTP ports
+s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM)
+s.connect(('8.8.8.8',53))
+myip=s.getsockname()[0]
+s.close()
+
 # port parameters (zgrab2 module syntax)
 pparms={
         '22': 'ssh --port 22 --host-key-algorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss,ssh-ed25519',
-        '25': 'smtp --port 25',
-        '110': 'pop3 --port 110 --starttls',
-        '143': 'imap --port 143 --starttls',
-        '443': 'http --port 443 --use-https --max-redirects=5',
-        '587': 'smtp --port 587',
-        '993': 'imap --port 993 --imaps',
+        '25': 'smtp --port 25 --max-version=771',
+        '110': 'pop3 --port 110 --starttls --max-version=771',
+        '143': 'imap --port 143 --starttls --max-version=771',
+        '443': 'http --port 443 --use-https --max-version=771',
+        '587': 'smtp --port 587 --max-version=771',
+        '993': 'imap --port 993 --imaps --max-version=771',
         }
 
 def zgrab2_to_v1(port, v2_result):
@@ -195,7 +201,10 @@ with open(args.infile,'r') as f:
             try:
                 cmd='zgrab2 '+  pparms[port] + ztimeout
                 proc=subprocess.Popen(cmd.split(),stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-                pc=proc.communicate(input=(ip+',localhost').encode())
+                # for SMTP ports send our own  IP as the EHLO name;
+                # all other ports send the target IP so http/TLS hits the real host
+                name='['+myip+']' if port in ('25','587') else ip
+                pc=proc.communicate(input=(ip+','+name).encode())
                 out=pc[0].decode("utf-8").strip()
                 jres=json.loads(out)
                 jres=zgrab2_to_v1(port, jres)

--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -68,7 +68,7 @@ ztimeout=' -t 2s'
 
 # port parameters (zgrab2 module syntax)
 pparms={
-        '22': 'ssh --port 22 --host-key-algorithms ecdsa-sha2-nistp256,ssh-rsa,ecdsa-sha2-nistp521,ssh-ed25519,ecdsa-sha2-nistp384,ssh-dss',
+        '22': 'ssh --port 22 --host-key-algorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss,ssh-ed25519',
         '25': 'smtp --port 25',
         '110': 'pop3 --port 110 --starttls',
         '143': 'imap --port 143 --starttls',

--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -63,19 +63,47 @@ country=def_country
 if args.country is not None:
     country=args.country
 
-# default timeout for zgrab, in seconds
-ztimeout=' -timeout 2'
+# default timeout for zgrab2, in seconds
+ztimeout=' -t 2s'
 
-# port parameters
-pparms={ 
-        '22': '-port 22 -xssh',
-        '25': '-port 25 -smtp -starttls -banners',
-        '110': '-port 110 -pop3 -starttls -banners',
-        '143': '-port 143 -imap -starttls -banners',
-        '443': '-port 443 -tls -http /',
-        '587': '-port 587 -smtp -starttls -banners',
-        '993': '-port 993 -imap -tls -banners',
+# port parameters (zgrab2 module syntax)
+pparms={
+        '22': 'ssh --port 22',
+        '25': 'smtp --port 25',
+        '110': 'pop3 --port 110 --starttls',
+        '143': 'imap --port 143 --starttls',
+        '443': 'http --port 443 --use-https',
+        '587': 'smtp --port 587',
+        '993': 'imap --port 993 --imaps',
         }
+
+def translate_v2(port, v2_result):
+    try:
+        data=v2_result.get('data',{})
+        module=next(iter(data))
+        result=data[module].get('result',{})
+    except Exception:
+        return v2_result
+    if 'tls' in result:
+        hl=result['tls'].get('handshake_log')
+        if hl is not None:
+            result['tls']=hl
+    v1={'ip': v2_result.get('ip','')}
+    if module == 'http':
+        try:
+            req=result['response']['request']
+            tl=req.get('tls_log',{}).get('handshake_log')
+            if tl is not None:
+                req['tls_handshake']=tl
+                del req['tls_log']
+        except (KeyError, TypeError):
+            pass
+        v1['data']={'http': result}
+    elif module == 'ssh':
+        v1['data']={'xssh': result}
+    else:
+        v1['data']=result
+    return v1
 
 def usage():
     print("usage: " + sys.argv[0] + " -i <infile> -o <putfile> [-p <portlist>] [-s <sleepsecs>]", file=sys.stderr)
@@ -165,14 +193,12 @@ with open(args.infile,'r') as f:
         jthing['writer']="FreshGrab.py"
         for port in ports:
             try:
-                cmd='zgrab '+  pparms[port] + ztimeout
+                cmd='zgrab2 '+  pparms[port] + ztimeout
                 proc=subprocess.Popen(cmd.split(),stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-                pc=proc.communicate(input=ip.encode())
-                lines=pc[0].decode("utf-8").split('\n')
-                jinfo=json.loads(lines[1])
-                jres=json.loads(lines[0])
-                #print jinfo
-                #print jres
+                pc=proc.communicate(input=(ip+',localhost').encode())
+                out=pc[0].decode("utf-8").strip()
+                jres=json.loads(out)
+                jres=translate_v2(port, jres)
                 jthing['p'+port]=jres
             except Exception as e:
                 # something goes wrong, we just record what

--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -77,7 +77,7 @@ pparms={
         '993': 'imap --port 993 --imaps',
         }
 
-def translate_v2(port, v2_result):
+def zgrab2_to_v1(port, v2_result):
     try:
         data=v2_result.get('data',{})
         module=next(iter(data))
@@ -92,9 +92,9 @@ def translate_v2(port, v2_result):
     if module == 'http':
         try:
             req=result['response']['request']
-            tl=req.get('tls_log',{}).get('handshake_log')
-            if tl is not None:
-                req['tls_handshake']=tl
+            hl=req.get('tls_log',{}).get('handshake_log')
+            if hl is not None:
+                req['tls_handshake']=hl
                 del req['tls_log']
         except (KeyError, TypeError):
             pass
@@ -198,7 +198,7 @@ with open(args.infile,'r') as f:
                 pc=proc.communicate(input=(ip+',localhost').encode())
                 out=pc[0].decode("utf-8").strip()
                 jres=json.loads(out)
-                jres=translate_v2(port, jres)
+                jres=zgrab2_to_v1(port, jres)
                 jthing['p'+port]=jres
             except Exception as e:
                 # something goes wrong, we just record what

--- a/FreshGrab.py
+++ b/FreshGrab.py
@@ -68,7 +68,7 @@ ztimeout=' -t 2s'
 
 # port parameters (zgrab2 module syntax)
 pparms={
-        '22': 'ssh --port 22',
+        '22': 'ssh --port 22 --host-key-algorithms ecdsa-sha2-nistp256,ssh-rsa,ecdsa-sha2-nistp521,ssh-ed25519,ecdsa-sha2-nistp384,ssh-dss',
         '25': 'smtp --port 25',
         '110': 'pop3 --port 110 --starttls',
         '143': 'imap --port 143 --starttls',

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -67,6 +67,86 @@ def zdns_ptr_bulk(ips):
     return result
 
 
+def zdns_a_bulk(names):
+    # Create a zdns subprocess for a forward A lookup (100 in a batch)
+    # Returns {name: ip}.
+    names=[n for n in names if n]
+    if not names:
+        return {}
+    try:
+        proc=subprocess.Popen(['zdns','A'],
+                              stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        out,_=proc.communicate(input=("\n".join(names)+"\n").encode())
+    except FileNotFoundError:
+        raise RuntimeError("Issue with zdns, check the command works")
+    result={}
+    for line in out.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj=json.loads(line)
+        except Exception:
+            continue
+        name=obj.get('name')
+        ar=obj.get('results',{}).get('A',{})
+        if ar.get('status')!='NOERROR':
+            continue
+        for a in ar.get('data',{}).get('answers',[]):
+            if a.get('type')=='A':
+                result[name]=a.get('answer','')
+                break
+    return result
+
+
+def candidate_names_for_blob(blob):
+    # Mirror the main loop's name extraction. Returns a set of candidate
+    # hostnames from p25 banner plus cert DN/SANs across all scanned ports.
+    names=set()
+    writer=blob.get('writer','')
+    # banner from p25
+    try:
+        if writer=='FreshGrab.py':
+            banner=blob['p25']['data']['banner']
+        else:
+            banner=blob['p25']['smtp']['starttls']['banner']
+        ts=banner.split()
+        if ts[0]=='220':
+            names.add(ts[1])
+        elif ts[0].startswith('220-'):
+            names.add(ts[0][4:])
+    except Exception:
+        pass
+    # cert names from each port - mirror the main loop's cert paths exactly
+    tmp={}
+    for port in ('p25','p110','p143','p443','p587','p993'):
+        try:
+            if writer=='FreshGrab.py':
+                if port=='p443':
+                    cert=blob[port]['data']['http']['response']['request']['tls_handshake']['server_certificates']['certificate']
+                else:
+                    cert=blob[port]['data']['tls']['server_certificates']['certificate']
+            else:
+                if port=='p25':
+                    cert=blob[port]['smtp']['starttls']['tls']['certificate']
+                elif port in ('p110','p143'):
+                    cert=blob[port]['pop3']['starttls']['tls']['certificate']
+                elif port=='p443':
+                    cert=blob[port]['https']['tls']['certificate']
+                elif port=='p993':
+                    cert=blob[port]['imaps']['tls']['tls']['certificate']['parsed']
+                else:
+                    continue
+            get_certnames(port,cert,tmp)
+        except Exception:
+            pass
+    for v in tmp.values():
+        if v:
+            names.add(v)
+    return names
+
+
 # default values
 infile="records.fresh"
 outfile="collisions.json"
@@ -166,6 +246,20 @@ else:
     print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
     ptr_dict=zdns_ptr_bulk(ptr_ips)
     print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
+
+    # using zdns to do a forward-DNS lookup in bulk
+    candidate_names=set()
+    candidate_names.update(v for v in ptr_dict.values() if v)
+    with open(infile,'r') as f:
+        for line in f:
+            try:
+                blob=json.loads(line)
+            except Exception:
+                continue
+            candidate_names.update(candidate_names_for_blob(blob))
+    print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
+    forward_dict=zdns_a_bulk(candidate_names)
+    print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)
 
     with open(infile,'r') as f:
         for line in f:
@@ -353,24 +447,20 @@ else:
             besty=[]
             nogood=True # assume none are good
             tmp={}
-            # try verify names a bit
+            # try verify names a bit (forward A looked up in bulk by zdns before the loop)
             for k in nameset:
                 v=nameset[k]
                 #print "checking: " + k + " " + v
                 # see if we can verify the value as matching our give IP
                 if v != '' and not fqdn_bogon(v):
-                    try:
-                        rip=socket.gethostbyname(v)
+                    rip=forward_dict.get(v)
+                    if rip is not None:
                         if rip == thisone.ip:
                             besty.append(k)
                         else:
                             tmp[k+'-ip']=rip
                         # some name has an IP, even if not what we expect
                         nogood=False
-                    except Exception as e: 
-                        #oddly, an NXDOMAIN seems to cause an exception, so these happen
-                        #print >> sys.stderr, "Error making DNS query for " + v + " for ip:" + thisone.ip + " " + str(e)
-                        pass
             for k in tmp:
                 nameset[k]=tmp[k]
             nameset['allbad']=nogood

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -38,7 +38,7 @@ from SurveyFuncs import *
 
 
 def zdns_ptr_bulk(ips):
-    # Create a zdns subprocess for a lookup (100 in a batch) 
+    # Create a zdns subprocess for a PTR lookup (100 in a batch)
     # Returns {ip: rdns}.
     try:
         proc=subprocess.Popen(['zdns','PTR'],
@@ -100,9 +100,8 @@ def zdns_a_bulk(names):
     return result
 
 
-def candidate_names_for_blob(blob):
-    # Mirror the main loop's name extraction. Returns a set of candidate
-    # hostnames from p25 banner plus cert DN/SANs across all scanned ports.
+def get_hostnames(blob):
+    # Returns a set of hostnames from p25 banner and DN/SANs across all scanned ports.
     names=set()
     writer=blob.get('writer','')
     # banner from p25
@@ -118,7 +117,6 @@ def candidate_names_for_blob(blob):
             names.add(ts[0][4:])
     except Exception:
         pass
-    # cert names from each port - mirror the main loop's cert paths exactly
     tmp={}
     for port in ('p25','p110','p143','p443','p587','p993'):
         try:
@@ -256,7 +254,7 @@ else:
                 blob=json.loads(line)
             except Exception:
                 continue
-            candidate_names.update(candidate_names_for_blob(blob))
+            candidate_names.update(get_hostnames(blob))
     print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
     forward_dict=zdns_a_bulk(candidate_names)
     print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -37,7 +37,7 @@ import pytz # for adding back TZ info to allow comparisons
 from SurveyFuncs import *
 
 
-def zdns_ptr_bulk(ips):
+def zdns_ptr(ips):
     # Create a zdns subprocess for a PTR lookup (100 in a batch)
     # Returns {ip: rdns}.
     try:
@@ -67,7 +67,7 @@ def zdns_ptr_bulk(ips):
     return result
 
 
-def zdns_a_bulk(names):
+def zdns_a(names):
     # Create a zdns subprocess for a forward A lookup (100 in a batch)
     # Returns {name: ip}.
     names=[n for n in names if n]
@@ -233,7 +233,7 @@ else:
     # keep track of how long this is taking per ip
     peripaverage=0
 
-    # using zdns to do a reverse-DNS lookup in bulk
+    # using zdns to do a reverse-DNS lookup
     ptr_ips=[]
     with open(infile,'r') as f:
         for line in f:
@@ -242,10 +242,10 @@ else:
             except Exception:
                 pass
     print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
-    ptr_dict=zdns_ptr_bulk(ptr_ips)
+    ptr_dict=zdns_ptr(ptr_ips)
     print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
 
-    # using zdns to do a forward-DNS lookup in bulk
+    # using zdns to do a forward-DNS lookup
     candidate_names=set()
     candidate_names.update(v for v in ptr_dict.values() if v)
     with open(infile,'r') as f:
@@ -256,7 +256,7 @@ else:
                 continue
             candidate_names.update(get_hostnames(blob))
     print("zdns A for "+str(len(candidate_names))+" names...",file=sys.stderr)
-    forward_dict=zdns_a_bulk(candidate_names)
+    forward_dict=zdns_a(candidate_names)
     print("zdns A got "+str(len(forward_dict))+" answers",file=sys.stderr)
 
     with open(infile,'r') as f:
@@ -302,7 +302,7 @@ else:
     
             thisone.analysis['nameset']={}
             nameset=thisone.analysis['nameset']
-            # name from reverse DNS (looked up in bulk by zdns before the loop)
+            # name from reverse DNS (looked up by zdns before the loop)
             rdns=ptr_dict.get(thisone.ip)
             if rdns is not None:
                 nameset['rdns']=rdns
@@ -445,7 +445,7 @@ else:
             besty=[]
             nogood=True # assume none are good
             tmp={}
-            # try verify names a bit (forward A looked up in bulk by zdns before the loop)
+            # try verify names a bit (forward A looked up by zdns before the loop)
             for k in nameset:
                 v=nameset[k]
                 #print "checking: " + k + " " + v

--- a/SameKeys.py
+++ b/SameKeys.py
@@ -26,7 +26,7 @@
 # figure out if we can get port 587 ever - looks like not, for now anyway
 # my FreshGrab's do have that but we don't for censys.io's Nov 2017 scans
 
-import os, sys, argparse, tempfile, gc
+import os, sys, argparse, tempfile, gc, subprocess
 import json
 import jsonpickle # install via  "$ sudo pip install -U jsonpickle"
 import time, datetime
@@ -34,7 +34,38 @@ from dateutil import parser as dparser  # for parsing time from comand line and 
 import pytz # for adding back TZ info to allow comparisons
 
 # our own stuff
-from SurveyFuncs import *  
+from SurveyFuncs import *
+
+
+def zdns_ptr_bulk(ips):
+    # Create a zdns subprocess for a lookup (100 in a batch) 
+    # Returns {ip: rdns}.
+    try:
+        proc=subprocess.Popen(['zdns','PTR'],
+                              stdin=subprocess.PIPE,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        out,_=proc.communicate(input=("\n".join(ips)+"\n").encode())
+    except FileNotFoundError:
+        raise RuntimeError("Issue with zdns, check the command works")
+    result={}
+    for line in out.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj=json.loads(line)
+        except Exception:
+            continue
+        ip=obj.get('name')
+        ptr=obj.get('results',{}).get('PTR',{})
+        if ptr.get('status')!='NOERROR':
+            continue
+        for a in ptr.get('data',{}).get('answers',[]):
+            if a.get('type')=='PTR':
+                result[ip]=a.get('answer','').rstrip('.')
+                break
+    return result
+
 
 # default values
 infile="records.fresh"
@@ -123,7 +154,19 @@ else:
     bads={}
     # keep track of how long this is taking per ip
     peripaverage=0
-    
+
+    # using zdns to do a reverse-DNS lookup in bulk
+    ptr_ips=[]
+    with open(infile,'r') as f:
+        for line in f:
+            try:
+                ptr_ips.append(json.loads(line)['ip'].strip())
+            except Exception:
+                pass
+    print("zdns PTR for "+str(len(ptr_ips))+" IPs...",file=sys.stderr)
+    ptr_dict=zdns_ptr_bulk(ptr_ips)
+    print("zdns PTR got "+str(len(ptr_dict))+" answers",file=sys.stderr)
+
     with open(infile,'r') as f:
         for line in f:
             ipstart=time.time()
@@ -167,16 +210,10 @@ else:
     
             thisone.analysis['nameset']={}
             nameset=thisone.analysis['nameset']
-            try:
-                # name from reverse DNS
-                rdnsrec=socket.gethostbyaddr(thisone.ip)
-                rdns=rdnsrec[0]
-                #print "FQDN reverse: " + str(rdns)
+            # name from reverse DNS (looked up in bulk by zdns before the loop)
+            rdns=ptr_dict.get(thisone.ip)
+            if rdns is not None:
                 nameset['rdns']=rdns
-            except Exception as e: 
-                #print >> sys.stderr, "FQDN reverse exception " + str(e) + " for record:" + thisone.ip
-                #nameset['rdns']=''
-                pass
     
             # name from banner
             try:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,11 +137,11 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
-# add zdns
+# add zdns and put on path
 go install github.com/zmap/zdns/v2@latest
 sudo ln -sf $HOME/go/bin/zdns /usr/local/bin/zdns
 
-# add zgrab2
+# add zgrab2 and put on path
 go install github.com/zmap/zgrab2@latest
 sudo ln -sf $HOME/go/bin/zgrab2 /usr/local/bin/zgrab2
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -130,13 +130,6 @@ mkdir -p $HOME/code/golang
 
 fi
 
-# got get stuff
-go get github.com/zmap/zgrab
-cd $GOPATH/src/github.com/zmap/zgrab
-go build
-# put it on PATH
-sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
-
 # add zdns and put on path
 go install github.com/zmap/zdns/v2@latest
 sudo ln -sf $HOME/go/bin/zdns /usr/local/bin/zdns

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,13 +137,13 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
-# add zdns - install disabled, current zdns needs Go >=1.25 (this
-# script still pins Go 1.10) and the repo layout has changed.
-# Recipe will be reinstated by the zgrab2 PR once the Go pin is bumped.
-#go get github.com/zmap/zdns
-#cd $GOPATH/src/github.com/zmap/zdns/zdns
-#go build
-#sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
+# add zdns
+go install github.com/zmap/zdns/v2@latest
+sudo ln -sf $HOME/go/bin/zdns /usr/local/bin/zdns
+
+# add zgrab2
+go install github.com/zmap/zgrab2@latest
+sudo ln -sf $HOME/go/bin/zgrab2 /usr/local/bin/zgrab2
 
 # get ciphersuite stuff
 cd $HOME/code/surveys/clustertools

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -107,17 +107,17 @@ sudo -H  apt -y install  python3-scipy
 # better get wget
 sudo apt-get -y install wget
 
-if [ ! -d /usr/lib/go-1.10 ]
+if [ ! -d /usr/lib/go-1.25 ]
 then
 mkdir -p $HOME/code/golang
 	cd $HOME/code/golang
-	GOTARBALL=go1.10.linux-amd64.tar.gz
+	GOTARBALL=go1.25.0.linux-amd64.tar.gz
 	GOURL=https://dl.google.com/go/$GOTARBALL
 	wget $GOURL
 	tar xzvf $GOTARBALL
-	sudo mv go /usr/lib/go-1.10
-	sudo ln -sf /usr/lib/go-1.10 /usr/lib/go
-	sudo ln -sf /usr/lib/go-1.10/bin/go /usr/bin/go
+	sudo mv go /usr/lib/go-1.25
+	sudo ln -sf /usr/lib/go-1.25 /usr/lib/go
+	sudo ln -sf /usr/lib/go-1.25/bin/go /usr/bin/go
 
 	# add GOPATH to .bashrc
 	donealready=`grep GOPATH $HOME/.bashrc`

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,12 +137,13 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
-# add zdns
-go get github.com/zmap/zdns
-cd $GOPATH/src/github.com/zmap/zdns/zdns
-go build
-# add to path
-sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
+# add zdns - install disabled, current zdns needs Go >=1.25 (this
+# script still pins Go 1.10) and the repo layout has changed.
+# Recipe will be reinstated by the zgrab2 PR once the Go pin is bumped.
+#go get github.com/zmap/zdns
+#cd $GOPATH/src/github.com/zmap/zdns/zdns
+#go build
+#sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
 
 # get ciphersuite stuff
 cd $HOME/code/surveys/clustertools

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -137,6 +137,13 @@ go build
 # put it on PATH
 sudo ln -sf $HOME/go/src/github.com/zmap/zgrab/zgrab /usr/local/bin
 
+# add zdns
+go get github.com/zmap/zdns
+cd $GOPATH/src/github.com/zmap/zdns/zdns
+go build
+# add to path
+sudo ln -sf $HOME/go/src/github.com/zmap/zdns/zdns/zdns /usr/local/bin
+
 # get ciphersuite stuff
 cd $HOME/code/surveys/clustertools
 if [ ! -f mapping-rfc.txt ]


### PR DESCRIPTION
Moves FreshGrab.py from old zgrab to zgrab2. SSH uses the zgrab key order first so it picks the same host key as before.

Set all TLS ports at --max-version=771 (TLS 1.2) as zgrab Go version 1.10 doesn't have a module for TLS.1.3. 

Depends on #6.

Tested: ran a full scan with zgrab2 and checked SSH picks the same key as old zgrab. And that the same responses are similar to using zgrab1 and zgrab2